### PR TITLE
Added ability to remove posts from private groups

### DIFF
--- a/src/slack-utils.coffee
+++ b/src/slack-utils.coffee
@@ -17,9 +17,14 @@ botname = process.env.HUBOT_BOT_NAME
 baseURL = 'https://slack.com/api'
 
 getHistory = (channel, cb) ->
-  request.get {url: "#{baseURL}/channels.history?token=#{token}&channel=#{channel}&count=15", json: true}, (err, res, history) ->
-    throw err if err
-    cb history
+  if (channel.substr(0,1) == "G")
+    request.get {url: "#{baseURL}/groups.history?token=#{token}&channel=#{channel}&count=15", json: true}, (err, res, history) ->
+      throw err if err
+      cb history
+  else
+    request.get {url: "#{baseURL}/channels.history?token=#{token}&channel=#{channel}&count=15", json: true}, (err, res, history) ->
+      throw err if err
+      cb history
 
 getUserId = (username, cb) ->
   request.get {url: "#{baseURL}/users.list?token=#{token}", json: true}, (err, res, users) ->


### PR DESCRIPTION
Slack distinguishes channels and private groups by the first character in the channel identifier (C vs. G, respectively).  This small change allows hubot to remove his posts from private groups in addition to channels.
